### PR TITLE
Remove liquid value setting in world generation

### DIFF
--- a/src/main/java/org/terasology/anotherWorld/decorator/layering/DefaultLayersDefinition.java
+++ b/src/main/java/org/terasology/anotherWorld/decorator/layering/DefaultLayersDefinition.java
@@ -25,7 +25,6 @@ import org.terasology.world.block.Block;
 import org.terasology.world.chunks.CoreChunk;
 import org.terasology.world.generation.Region;
 import org.terasology.world.generation.facets.SurfaceHeightFacet;
-import org.terasology.world.liquid.LiquidData;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -62,7 +61,6 @@ public class DefaultLayersDefinition implements LayersDefinition {
             for (int level = seaBottom; level <= seaTop; level++) {
 //                if (chunkRegion.encompasses(x, level, z)) {
                 chunk.setBlock(ChunkMath.calcBlockPos(x, level, z), layeringConfig.getSeaBlock());
-                chunk.setLiquid(ChunkMath.calcBlockPos(x, level, z), new LiquidData(layeringConfig.getSeaLiquid(), LiquidData.MAX_LIQUID_DEPTH));
 //                }
             }
         }

--- a/src/main/java/org/terasology/anotherWorld/decorator/layering/LayeringConfig.java
+++ b/src/main/java/org/terasology/anotherWorld/decorator/layering/LayeringConfig.java
@@ -16,19 +16,16 @@
 package org.terasology.anotherWorld.decorator.layering;
 
 import org.terasology.world.block.Block;
-import org.terasology.world.liquid.LiquidType;
 
 public class LayeringConfig {
     private Block bottomBlock;
     private Block mainBlock;
     private Block seaBlock;
-    private LiquidType seaLiquid;
 
-    public LayeringConfig(Block bottomBlock, Block mainBlock, Block seaBlock, LiquidType seaLiquid) {
+    public LayeringConfig(Block bottomBlock, Block mainBlock, Block seaBlock) {
         this.bottomBlock = bottomBlock;
         this.mainBlock = mainBlock;
         this.seaBlock = seaBlock;
-        this.seaLiquid = seaLiquid;
     }
 
     public Block getBottomBlock() {
@@ -41,9 +38,5 @@ public class LayeringConfig {
 
     public Block getSeaBlock() {
         return seaBlock;
-    }
-
-    public LiquidType getSeaLiquid() {
-        return seaLiquid;
     }
 }


### PR DESCRIPTION
This PR is required for other modules that use this and are also affected by the liquid removals. See linked PR's

See MovingBlocks/Terasology#3495 for more information